### PR TITLE
Log errno when SSL_ERROR_SYSCALL occurs

### DIFF
--- a/src/nc_ssl.c
+++ b/src/nc_ssl.c
@@ -36,7 +36,7 @@ log_ssl_error_code(int error_code, int ssl_routine_errno) {
         case SSL_ERROR_WANT_CONNECT: log_error("error string: SSL_ERROR_WANT_CONNECT"); break;
         case SSL_ERROR_WANT_ACCEPT: log_error("error string: SSL_ERROR_WANT_ACCEPT"); break;
         case SSL_ERROR_WANT_X509_LOOKUP: log_error("error string: SSL_ERROR_WANT_X509_LOOKUP"); break;
-        case SSL_ERROR_SYSCALL: log_error("error string: SSL_ERROR_SYSCALL, errno: %s", strerror(ssl_routine_errno)); break;
+        case SSL_ERROR_SYSCALL: log_error("error string: SSL_ERROR_SYSCALL, errno: %d (%s)", ssl_routine_errno, strerror(ssl_routine_errno)); break;
         case SSL_ERROR_SSL: log_error("error string: SSL_ERROR_SSL"); break;
     }
 


### PR DESCRIPTION
We frequently see errors like this:
```
[2018-03-30 18:01:02.172] nc_ssl.c:184 Failing SSL_shutdown due to unhandled error.
[2018-03-30 18:01:02.172] nc_ssl.c:24 SSL failed with error code: 5
[2018-03-30 18:01:02.172] nc_ssl.c:28 error:00000005:lib(0):func(0):DH lib
[2018-03-30 18:01:02.172] nc_ssl.c:30 error: error:00000000:lib(0):func(0):reason(0)
[2018-03-30 18:01:02.172] nc_ssl.c:39 error string: SSL_ERROR_SYSCALL
[2018-03-30 18:01:02.172] nc_server.c:354 failed to teardown ssl s 11
```

In some cases they don't seem impactful, but in other cases it's not clear if 
they are problematic. According to the man page there may be more info in errno:
```
SSL_ERROR_SYSCALL
           Some non-recoverable I/O error occurred.  The OpenSSL error queue may contain more information on the error.  For socket I/O on Unix systems, consult errno for details.
```
This prints errno so we can have another datapoint.


Tested locally that errno is printed.