### PR TITLE
Bump version to 0.4.3

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,8 @@
+ 2018-04-04 Stephen Panar <spanaro@google.com>
+    * twemproxy: version 0.4.3 internal Google Fabric release
+      fix memory leak when there are unhandled errors during shutdown
+      improve logging for SSL_ERROR_SYSCALL
+
  2018-14-03 Stephen Panaro <spanaro@google.com>
     * twemproxy: version 0.4.2 internal Google Fabric release
       add support for TLS mutual auth

--- a/configure.ac
+++ b/configure.ac
@@ -1,7 +1,7 @@
 # Define the package version numbers and the bug reporting address
 m4_define([NC_MAJOR], 0)
 m4_define([NC_MINOR], 4)
-m4_define([NC_PATCH], 2)
+m4_define([NC_PATCH], 3)
 m4_define([NC_BUGS], [manj@cs.stanford.edu])
 
 # Initialize autoconf

--- a/scripts/nutcracker.spec
+++ b/scripts/nutcracker.spec
@@ -1,6 +1,6 @@
 Summary: Twitter's nutcracker redis and memcached proxy
 Name: nutcracker
-Version: 0.4.2
+Version: 0.4.3
 Release: 1
 
 URL: https://github.com/twitter/twemproxy/
@@ -66,6 +66,10 @@ fi
 %config(noreplace)%{_sysconfdir}/%{name}/%{name}.yml
 
 %changelog
+* Wed Apr 4 2018  Stephen Panaro  <spanaro@google.com>
+- twemproxy: version 0.4.3 internal Google Fabric release
+- fix memory leak when there are unhandled errors during shutdown
+- improve logging for SSL_ERROR_SYSCALL
 * Wed Mar 14 2018  Stephen Panaro  <spanaro@google.com>
 - twemproxy: version 0.4.2 internal Google Fabric release
 - add support for TLS mutual auth

--- a/tests/test_redis/test_protocol.py
+++ b/tests/test_redis/test_protocol.py
@@ -37,14 +37,14 @@ def test_pingpong():
     _test(req, resp)
 
 def test_quit():
-    if nc.version() < '0.4.3':
+    if nc.version() < '0.4.4':
         return
     req = '*1\r\n$4\r\nQUIT\r\n'
     resp = '+OK\r\n'
     _test(req, resp)
 
 def test_quit_without_recv():
-    if nc.version() < '0.4.3':
+    if nc.version() < '0.4.4':
         return
     req = '*1\r\n$4\r\nQUIT\r\n'
     resp = '+OK\r\n'

--- a/tests/test_system/test_reload.py
+++ b/tests/test_system/test_reload.py
@@ -59,7 +59,7 @@ def send_cmd(s, req, resp):
 
 @with_setup(_setup, _teardown)
 def test_reload_with_old_conf():
-    if nc.version() < '0.4.3':
+    if nc.version() < '0.4.4':
         print 'Ignore test_reload for version %s' % nc.version()
         return
     pid = nc.pid()
@@ -99,7 +99,7 @@ def test_reload_with_old_conf():
 
 @with_setup(_setup, _teardown)
 def test_new_port():
-    if nc.version() < '0.4.3':
+    if nc.version() < '0.4.4':
         print 'Ignore test_reload for version %s' % nc.version()
         return
     r = redis.Redis(nc.host(), nc.port())
@@ -128,7 +128,7 @@ reload_test:
 
 @with_setup(_setup, _teardown)
 def test_pool_add_del():
-    if nc.version() < '0.4.3':
+    if nc.version() < '0.4.4':
         print 'Ignore test_reload for version %s' % nc.version()
         return
 


### PR DESCRIPTION
Picks up #2 and #3

Validated:
```
phobos ➜  twemproxy git:(bump-version-ssl-bugfixes-4-3) ✗ src/nutcracker --version
This is nutcracker-0.4.3
```