### PR TITLE
Fix timeouts when messages span multiple SSL records

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,7 @@
+ 2018-04-05 Stephen Panar <spanaro@google.com>
+    * twemproxy: version 0.4.4 internal Google Fabric release
+      stop blocking the process when server responses span multiple SSL records
+
  2018-04-04 Stephen Panar <spanaro@google.com>
     * twemproxy: version 0.4.3 internal Google Fabric release
       fix memory leak when there are unhandled errors during shutdown

--- a/configure.ac
+++ b/configure.ac
@@ -1,7 +1,7 @@
 # Define the package version numbers and the bug reporting address
 m4_define([NC_MAJOR], 0)
 m4_define([NC_MINOR], 4)
-m4_define([NC_PATCH], 3)
+m4_define([NC_PATCH], 4)
 m4_define([NC_BUGS], [manj@cs.stanford.edu])
 
 # Initialize autoconf

--- a/scripts/nutcracker.spec
+++ b/scripts/nutcracker.spec
@@ -1,6 +1,6 @@
 Summary: Twitter's nutcracker redis and memcached proxy
 Name: nutcracker
-Version: 0.4.3
+Version: 0.4.4
 Release: 1
 
 URL: https://github.com/twitter/twemproxy/
@@ -66,6 +66,9 @@ fi
 %config(noreplace)%{_sysconfdir}/%{name}/%{name}.yml
 
 %changelog
+* Wed Apr 5 2018  Stephen Panaro  <spanaro@google.com>
+- twemproxy: version 0.4.4 internal Google Fabric release
+- stop blocking the process when server responses span multiple SSL records
 * Wed Apr 4 2018  Stephen Panaro  <spanaro@google.com>
 - twemproxy: version 0.4.3 internal Google Fabric release
 - fix memory leak when there are unhandled errors during shutdown
@@ -116,7 +119,7 @@ fi
 - support for set ex/px/nx/xx for redis 2.6.12 and up (ypocat)
 - kqueue (bsd) support (ferenyx)
 - fix parsing redis response to accept integer reply (charsyam)
-      
+
 * Tue Jul 30 2013 Tait Clarridge <tait@clarridge.ca>
 - Rebuild SPEC to work with CentOS
 - Added buildrequires if building with mock/koji

--- a/tests/test_redis/test_protocol.py
+++ b/tests/test_redis/test_protocol.py
@@ -37,14 +37,14 @@ def test_pingpong():
     _test(req, resp)
 
 def test_quit():
-    if nc.version() < '0.4.4':
+    if nc.version() < '0.4.5':
         return
     req = '*1\r\n$4\r\nQUIT\r\n'
     resp = '+OK\r\n'
     _test(req, resp)
 
 def test_quit_without_recv():
-    if nc.version() < '0.4.4':
+    if nc.version() < '0.4.5':
         return
     req = '*1\r\n$4\r\nQUIT\r\n'
     resp = '+OK\r\n'

--- a/tests/test_system/test_reload.py
+++ b/tests/test_system/test_reload.py
@@ -59,7 +59,7 @@ def send_cmd(s, req, resp):
 
 @with_setup(_setup, _teardown)
 def test_reload_with_old_conf():
-    if nc.version() < '0.4.4':
+    if nc.version() < '0.4.5':
         print 'Ignore test_reload for version %s' % nc.version()
         return
     pid = nc.pid()
@@ -99,7 +99,7 @@ def test_reload_with_old_conf():
 
 @with_setup(_setup, _teardown)
 def test_new_port():
-    if nc.version() < '0.4.4':
+    if nc.version() < '0.4.5':
         print 'Ignore test_reload for version %s' % nc.version()
         return
     r = redis.Redis(nc.host(), nc.port())
@@ -128,7 +128,7 @@ reload_test:
 
 @with_setup(_setup, _teardown)
 def test_pool_add_del():
-    if nc.version() < '0.4.4':
+    if nc.version() < '0.4.5':
         print 'Ignore test_reload for version %s' % nc.version()
         return
 


### PR DESCRIPTION
## Description
From the SSL_read man page:
```
SSL_read() works based on the SSL/TLS records. The data are received in
records (with a maximum record size of 16kB for SSLv3/TLSv1). Only when
a record has been completely received, it can be processed (decryption
and check of integrity). Therefore data that was not retrieved at the
last call of SSL_read() can still be buffered inside the SSL layer and
will be retrieved on the next call to SSL_read().
```

Due to this buffering of record data in the SSL layer, sometimes SSL_read returns only a portion of the data that has been read from the socket. This is usually fine, but twemproxy uses epoll_wait on the socket to trigger processing of data. Since the SSL layer has read data from the socket but not returned it for processing, there is no more pending data on the socket to trigger processing. This causes the twemproxy to get stuck between receiving and processing this data. Ultimately the connection times out.

To resolve this, we want to detect when data is buffered in SSL_read so that we can read as much as possible. SSL_pending should return that there is data buffered, but it does not do this reliably. Instead, we call SSL_read until it returns no more data.

This discussion is the same problem and solution: http://openssl.6102.n7.nabble.com/OpenSSL-non-blocking-epoll-hanging-on-data-receiving-td66355.html

## How was this tested?
Tested by requesting small and large (34kB) values from Redis and validating them.
Also tested setting + getting every size value in 200 byte intervals from 14kB to 50kB. (14000 bytes, 14200 bytes, 14400 bytes etc).
None of these blocked or failed.

Ran these tests with `-fsanitize=address -O1 -fno-omit-frame-pointer -g` to check for leaks.